### PR TITLE
Add functions to generate attestation models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ admin_seed.txt
 composedb.config.json
 node_modules/*
 src/__generated__/*
+.ceramic

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,6 @@
         "@ceramicnetwork/http-client": "2.30.0",
         "@composedb/cli": "0.5.0",
         "@composedb/client": "0.5.0",
-        "@composedb/devtools": "0.5.0",
-        "@composedb/devtools-node": "0.5.0",
         "@didtools/cacao": "2.0.0",
         "@didtools/pkh-ethereum": "0.1.0",
         "@ethereum-attestation-service/eas-sdk": "^0.29.0",
@@ -45,6 +43,9 @@
         "zod": "^3.21.4"
       },
       "devDependencies": {
+        "@ceramicnetwork/stream-model": "^1.17.0",
+        "@composedb/devtools": "^0.5.0",
+        "@composedb/devtools-node": "^0.5.1",
         "@composedb/types": "^0.3.0",
         "@datamodels/identity-profile-basic": "^0.2.0",
         "@glazed/types": "^0.2.0",
@@ -3326,9 +3327,9 @@
       }
     },
     "node_modules/@ceramicnetwork/codecs": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/codecs/-/codecs-1.8.0.tgz",
-      "integrity": "sha512-d1X6sJyJoO7urV6hWaLc+IJoSFlaANz6uqaspMqH2XKJW44oFJz4/GuhrKoGXqhkcyeB+sEs5OfJkAV95uv0UA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/codecs/-/codecs-1.10.0.tgz",
+      "integrity": "sha512-0/5/NCjKax2UFbvnlQuRzZ+T7sp+HKgGsBsW/fKK06E/ui0MBVMSK1eitn/ozvMFUo+nCjKPQF3ixXVpdsQl4A==",
       "dependencies": {
         "@ceramicnetwork/streamid": "^2.17.0",
         "cartonne": "^2.1.1",
@@ -3683,11 +3684,11 @@
       }
     },
     "node_modules/@ceramicnetwork/stream-caip10-link": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/stream-caip10-link/-/stream-caip10-link-2.28.0.tgz",
-      "integrity": "sha512-ORsXJxU6f78Kd9G3uB5Q/EqiiUhIPT9UKECY41UbVtiWA7U32xs6Fr4jar3JIDK54bPlRp9XB74NRhb600LEFA==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/stream-caip10-link/-/stream-caip10-link-2.30.0.tgz",
+      "integrity": "sha512-co6M+gKp2ShsLa1pxJScLBY+ICenN0asuA3ZFlLqquLcYAdXTYuLs37NaLSxkuTr41sI0HLSwzJVN8OBwjhvQg==",
       "dependencies": {
-        "@ceramicnetwork/common": "^2.33.0",
+        "@ceramicnetwork/common": "^2.35.0",
         "@ceramicnetwork/streamid": "^2.17.0",
         "caip": "~1.1.0",
         "did-resolver": "^4.0.1",
@@ -3705,6 +3706,77 @@
         "@ceramicnetwork/stream-handler-common": "^1.23.0"
       }
     },
+    "node_modules/@ceramicnetwork/stream-caip10-link/node_modules/@ceramicnetwork/common": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-2.35.0.tgz",
+      "integrity": "sha512-1TsdVYAjTIVTBz+6dlrEJACFGqMzYZeOvwLNbpk9E5vMh6fnrgRm8q9JPeGhDyGwdGlY7l4e1yqzWAoZGnJARQ==",
+      "dependencies": {
+        "@ceramicnetwork/codecs": "^1.10.0",
+        "@ceramicnetwork/streamid": "^2.17.0",
+        "@didtools/cacao": "^2.1.0",
+        "@didtools/pkh-ethereum": "^0.1.0",
+        "@didtools/pkh-solana": "^0.1.0",
+        "@didtools/pkh-stacks": "^0.1.0",
+        "@didtools/pkh-tezos": "^0.2.1",
+        "@stablelib/random": "^1.0.1",
+        "caip": "~1.1.0",
+        "cross-fetch": "^3.1.4",
+        "flat": "^5.0.2",
+        "it-first": "^1.0.7",
+        "jet-logger": "1.2.2",
+        "lodash.clonedeep": "^4.5.0",
+        "logfmt": "^1.3.2",
+        "multiformats": "^11.0.1",
+        "rxjs": "^7.5.2",
+        "uint8arrays": "^4.0.3"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-caip10-link/node_modules/@didtools/cacao": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@didtools/cacao/-/cacao-2.1.0.tgz",
+      "integrity": "sha512-35gopj+mOmAlA3nHoHiYMvNMXJtbJDJnVpIlCf/Wf/+/x+uG9aIQefXfF35D6JuaTCZ0apabjpT2umL5h3EXcw==",
+      "dependencies": {
+        "@didtools/codecs": "^1.0.1",
+        "@didtools/siwx": "1.0.0",
+        "@ipld/dag-cbor": "^9.0.1",
+        "caip": "^1.1.0",
+        "multiformats": "^11.0.2",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-caip10-link/node_modules/@ipld/dag-cbor": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.5.tgz",
+      "integrity": "sha512-TyqgtxEojc98rvxg4NGM+73JzQeM4+tK2VQes/in2mdyhO+1wbGuBijh1tvi9BErQ/dEblxs9v4vEQSX8mFCIw==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-caip10-link/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-caip10-link/node_modules/cborg": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.3.tgz",
+      "integrity": "sha512-poLvpK30KT5KI8gzDx3J/IuVCbsLqMT2fEbOrOuX0H7Hyj8yg5LezeWhRh9aLa5Z6MfPC5sriW3HVJF328M8LQ==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
     "node_modules/@ceramicnetwork/stream-handler-common": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@ceramicnetwork/stream-handler-common/-/stream-handler-common-1.23.0.tgz",
@@ -3716,12 +3788,12 @@
       }
     },
     "node_modules/@ceramicnetwork/stream-model": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/stream-model/-/stream-model-1.15.0.tgz",
-      "integrity": "sha512-F1UaBh2EZ8tykXj4kBqlUqgn639bUKgvfc9eQ3WR3nsYM+qFruQAXBcCcK0bdMbFyzDTK0uoa+JX2Oa1nioWfQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/stream-model/-/stream-model-1.17.0.tgz",
+      "integrity": "sha512-d6HhiPAQfyw0a1wN32kWR/YdGdLd6DdOfhn3pDU8vHKH731l5uHIIOMwwp+XEcbFTSGQdPbxAbcdTM4AFJG3MA==",
       "dependencies": {
-        "@ceramicnetwork/codecs": "^1.8.0",
-        "@ceramicnetwork/common": "^2.33.0",
+        "@ceramicnetwork/codecs": "^1.10.0",
+        "@ceramicnetwork/common": "^2.35.0",
         "@ceramicnetwork/streamid": "^2.17.0",
         "@ipld/dag-cbor": "^7.0.0",
         "@stablelib/random": "^1.0.1",
@@ -3751,11 +3823,11 @@
       }
     },
     "node_modules/@ceramicnetwork/stream-model-instance": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/stream-model-instance/-/stream-model-instance-1.15.0.tgz",
-      "integrity": "sha512-lkcDA4w1kpcz6m3LRInIqJa32LnwZVgT/qmvMzBSWWNDecuZByHVYXOq7lk841MfxDvSZDL/MG+r0Uh9ip+GvA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/stream-model-instance/-/stream-model-instance-1.17.0.tgz",
+      "integrity": "sha512-cVHlz7ScpLYgz11Wzw5x99dh4BbThoKsJi9rFS2RF+p0BNuyp2QgSnpCjziEQqCz6djJngy6g2BCwf4b+MML5g==",
       "dependencies": {
-        "@ceramicnetwork/common": "^2.33.0",
+        "@ceramicnetwork/common": "^2.35.0",
         "@ceramicnetwork/streamid": "^2.17.0",
         "@ipld/dag-cbor": "^7.0.0",
         "@stablelib/random": "^1.0.1",
@@ -3781,12 +3853,154 @@
         "uint8arrays": "^4.0.3"
       }
     },
-    "node_modules/@ceramicnetwork/stream-tile": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/stream-tile/-/stream-tile-2.29.0.tgz",
-      "integrity": "sha512-e++L/JzawcjENsCk/SMXiLbDsEGeTQvwq+MV4kylmsKX4ZstKDZG2vkaGHhu4zwt4wT4nHBMvS/0ZJdbwXMQ5A==",
+    "node_modules/@ceramicnetwork/stream-model-instance/node_modules/@ceramicnetwork/common": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-2.35.0.tgz",
+      "integrity": "sha512-1TsdVYAjTIVTBz+6dlrEJACFGqMzYZeOvwLNbpk9E5vMh6fnrgRm8q9JPeGhDyGwdGlY7l4e1yqzWAoZGnJARQ==",
       "dependencies": {
-        "@ceramicnetwork/common": "^2.33.0",
+        "@ceramicnetwork/codecs": "^1.10.0",
+        "@ceramicnetwork/streamid": "^2.17.0",
+        "@didtools/cacao": "^2.1.0",
+        "@didtools/pkh-ethereum": "^0.1.0",
+        "@didtools/pkh-solana": "^0.1.0",
+        "@didtools/pkh-stacks": "^0.1.0",
+        "@didtools/pkh-tezos": "^0.2.1",
+        "@stablelib/random": "^1.0.1",
+        "caip": "~1.1.0",
+        "cross-fetch": "^3.1.4",
+        "flat": "^5.0.2",
+        "it-first": "^1.0.7",
+        "jet-logger": "1.2.2",
+        "lodash.clonedeep": "^4.5.0",
+        "logfmt": "^1.3.2",
+        "multiformats": "^11.0.1",
+        "rxjs": "^7.5.2",
+        "uint8arrays": "^4.0.3"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-model-instance/node_modules/@didtools/cacao": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@didtools/cacao/-/cacao-2.1.0.tgz",
+      "integrity": "sha512-35gopj+mOmAlA3nHoHiYMvNMXJtbJDJnVpIlCf/Wf/+/x+uG9aIQefXfF35D6JuaTCZ0apabjpT2umL5h3EXcw==",
+      "dependencies": {
+        "@didtools/codecs": "^1.0.1",
+        "@didtools/siwx": "1.0.0",
+        "@ipld/dag-cbor": "^9.0.1",
+        "caip": "^1.1.0",
+        "multiformats": "^11.0.2",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-model-instance/node_modules/@didtools/cacao/node_modules/@ipld/dag-cbor": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.5.tgz",
+      "integrity": "sha512-TyqgtxEojc98rvxg4NGM+73JzQeM4+tK2VQes/in2mdyhO+1wbGuBijh1tvi9BErQ/dEblxs9v4vEQSX8mFCIw==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-model-instance/node_modules/@didtools/cacao/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-model-instance/node_modules/cborg": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.3.tgz",
+      "integrity": "sha512-poLvpK30KT5KI8gzDx3J/IuVCbsLqMT2fEbOrOuX0H7Hyj8yg5LezeWhRh9aLa5Z6MfPC5sriW3HVJF328M8LQ==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-model/node_modules/@ceramicnetwork/common": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-2.35.0.tgz",
+      "integrity": "sha512-1TsdVYAjTIVTBz+6dlrEJACFGqMzYZeOvwLNbpk9E5vMh6fnrgRm8q9JPeGhDyGwdGlY7l4e1yqzWAoZGnJARQ==",
+      "dependencies": {
+        "@ceramicnetwork/codecs": "^1.10.0",
+        "@ceramicnetwork/streamid": "^2.17.0",
+        "@didtools/cacao": "^2.1.0",
+        "@didtools/pkh-ethereum": "^0.1.0",
+        "@didtools/pkh-solana": "^0.1.0",
+        "@didtools/pkh-stacks": "^0.1.0",
+        "@didtools/pkh-tezos": "^0.2.1",
+        "@stablelib/random": "^1.0.1",
+        "caip": "~1.1.0",
+        "cross-fetch": "^3.1.4",
+        "flat": "^5.0.2",
+        "it-first": "^1.0.7",
+        "jet-logger": "1.2.2",
+        "lodash.clonedeep": "^4.5.0",
+        "logfmt": "^1.3.2",
+        "multiformats": "^11.0.1",
+        "rxjs": "^7.5.2",
+        "uint8arrays": "^4.0.3"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-model/node_modules/@didtools/cacao": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@didtools/cacao/-/cacao-2.1.0.tgz",
+      "integrity": "sha512-35gopj+mOmAlA3nHoHiYMvNMXJtbJDJnVpIlCf/Wf/+/x+uG9aIQefXfF35D6JuaTCZ0apabjpT2umL5h3EXcw==",
+      "dependencies": {
+        "@didtools/codecs": "^1.0.1",
+        "@didtools/siwx": "1.0.0",
+        "@ipld/dag-cbor": "^9.0.1",
+        "caip": "^1.1.0",
+        "multiformats": "^11.0.2",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-model/node_modules/@didtools/cacao/node_modules/@ipld/dag-cbor": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.5.tgz",
+      "integrity": "sha512-TyqgtxEojc98rvxg4NGM+73JzQeM4+tK2VQes/in2mdyhO+1wbGuBijh1tvi9BErQ/dEblxs9v4vEQSX8mFCIw==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-model/node_modules/@didtools/cacao/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-model/node_modules/cborg": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.3.tgz",
+      "integrity": "sha512-poLvpK30KT5KI8gzDx3J/IuVCbsLqMT2fEbOrOuX0H7Hyj8yg5LezeWhRh9aLa5Z6MfPC5sriW3HVJF328M8LQ==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-tile": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/stream-tile/-/stream-tile-2.31.0.tgz",
+      "integrity": "sha512-Vky2XyT38jqpQYVT4jzVmjmRWDU/T5Gx2wdCNuQsIYw6DkrMLSa0nTOMnqHTFl+hf+wcfNIpNvUI7RmooKoY7g==",
+      "dependencies": {
+        "@ceramicnetwork/common": "^2.35.0",
         "@ceramicnetwork/streamid": "^2.17.0",
         "@ipld/dag-cbor": "^7.0.0",
         "@stablelib/random": "^1.0.1",
@@ -3810,6 +4024,31 @@
         "fast-json-patch": "^3.1.0",
         "least-recent": "^1.0.3",
         "lodash.clonedeep": "^4.5.0",
+        "uint8arrays": "^4.0.3"
+      }
+    },
+    "node_modules/@ceramicnetwork/stream-tile/node_modules/@ceramicnetwork/common": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-2.35.0.tgz",
+      "integrity": "sha512-1TsdVYAjTIVTBz+6dlrEJACFGqMzYZeOvwLNbpk9E5vMh6fnrgRm8q9JPeGhDyGwdGlY7l4e1yqzWAoZGnJARQ==",
+      "dependencies": {
+        "@ceramicnetwork/codecs": "^1.10.0",
+        "@ceramicnetwork/streamid": "^2.17.0",
+        "@didtools/cacao": "^2.1.0",
+        "@didtools/pkh-ethereum": "^0.1.0",
+        "@didtools/pkh-solana": "^0.1.0",
+        "@didtools/pkh-stacks": "^0.1.0",
+        "@didtools/pkh-tezos": "^0.2.1",
+        "@stablelib/random": "^1.0.1",
+        "caip": "~1.1.0",
+        "cross-fetch": "^3.1.4",
+        "flat": "^5.0.2",
+        "it-first": "^1.0.7",
+        "jet-logger": "1.2.2",
+        "lodash.clonedeep": "^4.5.0",
+        "logfmt": "^1.3.2",
+        "multiformats": "^11.0.1",
+        "rxjs": "^7.5.2",
         "uint8arrays": "^4.0.3"
       }
     },
@@ -4376,14 +4615,14 @@
       }
     },
     "node_modules/@composedb/devtools-node": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@composedb/devtools-node/-/devtools-node-0.5.0.tgz",
-      "integrity": "sha512-dKf4iI23qUb3bpzPzLPLVUndE6pl0flTaL/DVlSuc3tDZDu2iQsuugkthnBHN+XSJTY9zr3PoHqLwMdnfXxSKQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@composedb/devtools-node/-/devtools-node-0.5.1.tgz",
+      "integrity": "sha512-OAoMY4vXHrOkRvs2KHgkKOO/PzT9EpDni35Dt1sh+k6Jh9ZAalnV7rDAJ9DMRhV//zuKXhgWwsNrEwEv1xVSHA==",
       "dependencies": {
-        "@ceramicnetwork/http-client": "^2.30.0",
-        "@composedb/client": "^0.5.0",
-        "@composedb/runtime": "^0.5.0",
-        "@composedb/server": "^0.5.0",
+        "@ceramicnetwork/http-client": "^2.31.0",
+        "@composedb/client": "^0.5.1",
+        "@composedb/runtime": "^0.5.1",
+        "@composedb/server": "^0.5.1",
         "fs-extra": "^11.1.1"
       },
       "engines": {
@@ -4391,6 +4630,115 @@
       },
       "peerDependencies": {
         "@composedb/devtools": "^0.5.0"
+      }
+    },
+    "node_modules/@composedb/devtools-node/node_modules/@ceramicnetwork/common": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-2.35.0.tgz",
+      "integrity": "sha512-1TsdVYAjTIVTBz+6dlrEJACFGqMzYZeOvwLNbpk9E5vMh6fnrgRm8q9JPeGhDyGwdGlY7l4e1yqzWAoZGnJARQ==",
+      "dependencies": {
+        "@ceramicnetwork/codecs": "^1.10.0",
+        "@ceramicnetwork/streamid": "^2.17.0",
+        "@didtools/cacao": "^2.1.0",
+        "@didtools/pkh-ethereum": "^0.1.0",
+        "@didtools/pkh-solana": "^0.1.0",
+        "@didtools/pkh-stacks": "^0.1.0",
+        "@didtools/pkh-tezos": "^0.2.1",
+        "@stablelib/random": "^1.0.1",
+        "caip": "~1.1.0",
+        "cross-fetch": "^3.1.4",
+        "flat": "^5.0.2",
+        "it-first": "^1.0.7",
+        "jet-logger": "1.2.2",
+        "lodash.clonedeep": "^4.5.0",
+        "logfmt": "^1.3.2",
+        "multiformats": "^11.0.1",
+        "rxjs": "^7.5.2",
+        "uint8arrays": "^4.0.3"
+      }
+    },
+    "node_modules/@composedb/devtools-node/node_modules/@ceramicnetwork/http-client": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/http-client/-/http-client-2.32.0.tgz",
+      "integrity": "sha512-2OUp33qXg2D243N+NwuwvPJfw/F2PFj2y73XT753yjwXIdyaHAJXwsoLJ8OyK1ixFYl1Q5Yb3kshO1sXurQi4g==",
+      "dependencies": {
+        "@ceramicnetwork/common": "^2.35.0",
+        "@ceramicnetwork/stream-caip10-link": "^2.30.0",
+        "@ceramicnetwork/stream-model": "^1.17.0",
+        "@ceramicnetwork/stream-model-instance": "^1.17.0",
+        "@ceramicnetwork/stream-tile": "^2.31.0",
+        "@ceramicnetwork/streamid": "^2.17.0",
+        "@scarf/scarf": "^1.1.1",
+        "query-string": "^7.1.0",
+        "rxjs": "^7.5.2"
+      }
+    },
+    "node_modules/@composedb/devtools-node/node_modules/@composedb/client": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@composedb/client/-/client-0.5.1.tgz",
+      "integrity": "sha512-EY9166O1JPiubEZrE+ZYWnRhJvqFuFJGTZjM3gHtNjLyYwgFbDwjvreMHZXYQX4FSrNqGm2yveJRWyBdQ9gnYg==",
+      "dependencies": {
+        "@ceramicnetwork/http-client": "^2.31.0",
+        "@ceramicnetwork/stream-model": "^1.16.0",
+        "@ceramicnetwork/stream-model-instance": "^1.16.0",
+        "@composedb/constants": "^0.5.0",
+        "@composedb/graphql-scalars": "^0.5.0",
+        "@composedb/runtime": "^0.5.1",
+        "@graphql-tools/batch-execute": "^9.0.2",
+        "@graphql-tools/stitch": "^9.0.1",
+        "@graphql-tools/utils": "^10.0.6",
+        "dataloader": "^2.2.2",
+        "graphql": "^16.8.0",
+        "graphql-relay": "^0.10.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@composedb/devtools-node/node_modules/@didtools/cacao": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@didtools/cacao/-/cacao-2.1.0.tgz",
+      "integrity": "sha512-35gopj+mOmAlA3nHoHiYMvNMXJtbJDJnVpIlCf/Wf/+/x+uG9aIQefXfF35D6JuaTCZ0apabjpT2umL5h3EXcw==",
+      "dependencies": {
+        "@didtools/codecs": "^1.0.1",
+        "@didtools/siwx": "1.0.0",
+        "@ipld/dag-cbor": "^9.0.1",
+        "caip": "^1.1.0",
+        "multiformats": "^11.0.2",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@composedb/devtools-node/node_modules/@ipld/dag-cbor": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.5.tgz",
+      "integrity": "sha512-TyqgtxEojc98rvxg4NGM+73JzQeM4+tK2VQes/in2mdyhO+1wbGuBijh1tvi9BErQ/dEblxs9v4vEQSX8mFCIw==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@composedb/devtools-node/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@composedb/devtools-node/node_modules/cborg": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.3.tgz",
+      "integrity": "sha512-poLvpK30KT5KI8gzDx3J/IuVCbsLqMT2fEbOrOuX0H7Hyj8yg5LezeWhRh9aLa5Z6MfPC5sriW3HVJF328M8LQ==",
+      "bin": {
+        "cborg": "lib/bin.js"
       }
     },
     "node_modules/@composedb/devtools/node_modules/multiformats": {
@@ -4581,13 +4929,13 @@
       }
     },
     "node_modules/@composedb/runtime": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@composedb/runtime/-/runtime-0.5.0.tgz",
-      "integrity": "sha512-sN8//2au2ckbDCxPAq2ZY73vujRbihZ4/ijO7vuvJJ8Q5HtcT8XBLLppQf0SNnGq/uzE2Emm+L5qvcOhkfcVBQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@composedb/runtime/-/runtime-0.5.1.tgz",
+      "integrity": "sha512-Vhv34i4lkHhtwUIRKXTozahKCDoiSn9BMpiu3c6pZxtoUAkQn9twikfX8QIXI5Ssmap6nDMlSxWxm4ASnxID0Q==",
       "dependencies": {
-        "@ceramicnetwork/http-client": "^2.30.0",
-        "@ceramicnetwork/stream-model": "^1.15.0",
-        "@ceramicnetwork/stream-model-instance": "^1.15.0",
+        "@ceramicnetwork/http-client": "^2.31.0",
+        "@ceramicnetwork/stream-model": "^1.16.0",
+        "@ceramicnetwork/stream-model-instance": "^1.16.0",
         "@ceramicnetwork/streamid": "^2.17.0",
         "@composedb/graphql-scalars": "^0.5.0",
         "dataloader": "^2.2.2",
@@ -4598,20 +4946,194 @@
         "node": ">=16"
       }
     },
-    "node_modules/@composedb/server": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@composedb/server/-/server-0.5.0.tgz",
-      "integrity": "sha512-nw1osiX3GMZdf6T3rDkqZe+/PA/zpsaLzZpbryLoX61I+vphijt25sHcLHJ3Jt5elsTISnBK9pdkFcCWrbAmdg==",
+    "node_modules/@composedb/runtime/node_modules/@ceramicnetwork/common": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-2.35.0.tgz",
+      "integrity": "sha512-1TsdVYAjTIVTBz+6dlrEJACFGqMzYZeOvwLNbpk9E5vMh6fnrgRm8q9JPeGhDyGwdGlY7l4e1yqzWAoZGnJARQ==",
       "dependencies": {
-        "@ceramicnetwork/http-client": "^2.30.0",
+        "@ceramicnetwork/codecs": "^1.10.0",
+        "@ceramicnetwork/streamid": "^2.17.0",
+        "@didtools/cacao": "^2.1.0",
+        "@didtools/pkh-ethereum": "^0.1.0",
+        "@didtools/pkh-solana": "^0.1.0",
+        "@didtools/pkh-stacks": "^0.1.0",
+        "@didtools/pkh-tezos": "^0.2.1",
+        "@stablelib/random": "^1.0.1",
+        "caip": "~1.1.0",
+        "cross-fetch": "^3.1.4",
+        "flat": "^5.0.2",
+        "it-first": "^1.0.7",
+        "jet-logger": "1.2.2",
+        "lodash.clonedeep": "^4.5.0",
+        "logfmt": "^1.3.2",
+        "multiformats": "^11.0.1",
+        "rxjs": "^7.5.2",
+        "uint8arrays": "^4.0.3"
+      }
+    },
+    "node_modules/@composedb/runtime/node_modules/@ceramicnetwork/http-client": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/http-client/-/http-client-2.32.0.tgz",
+      "integrity": "sha512-2OUp33qXg2D243N+NwuwvPJfw/F2PFj2y73XT753yjwXIdyaHAJXwsoLJ8OyK1ixFYl1Q5Yb3kshO1sXurQi4g==",
+      "dependencies": {
+        "@ceramicnetwork/common": "^2.35.0",
+        "@ceramicnetwork/stream-caip10-link": "^2.30.0",
+        "@ceramicnetwork/stream-model": "^1.17.0",
+        "@ceramicnetwork/stream-model-instance": "^1.17.0",
+        "@ceramicnetwork/stream-tile": "^2.31.0",
+        "@ceramicnetwork/streamid": "^2.17.0",
+        "@scarf/scarf": "^1.1.1",
+        "query-string": "^7.1.0",
+        "rxjs": "^7.5.2"
+      }
+    },
+    "node_modules/@composedb/runtime/node_modules/@didtools/cacao": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@didtools/cacao/-/cacao-2.1.0.tgz",
+      "integrity": "sha512-35gopj+mOmAlA3nHoHiYMvNMXJtbJDJnVpIlCf/Wf/+/x+uG9aIQefXfF35D6JuaTCZ0apabjpT2umL5h3EXcw==",
+      "dependencies": {
+        "@didtools/codecs": "^1.0.1",
+        "@didtools/siwx": "1.0.0",
+        "@ipld/dag-cbor": "^9.0.1",
+        "caip": "^1.1.0",
+        "multiformats": "^11.0.2",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@composedb/runtime/node_modules/@ipld/dag-cbor": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.5.tgz",
+      "integrity": "sha512-TyqgtxEojc98rvxg4NGM+73JzQeM4+tK2VQes/in2mdyhO+1wbGuBijh1tvi9BErQ/dEblxs9v4vEQSX8mFCIw==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@composedb/runtime/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@composedb/runtime/node_modules/cborg": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.3.tgz",
+      "integrity": "sha512-poLvpK30KT5KI8gzDx3J/IuVCbsLqMT2fEbOrOuX0H7Hyj8yg5LezeWhRh9aLa5Z6MfPC5sriW3HVJF328M8LQ==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/@composedb/server": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@composedb/server/-/server-0.5.1.tgz",
+      "integrity": "sha512-sg5Emyneeciu4vZRCLUY/1A3utkjh2UPJMsXxEsAvyzLP+Jx4PHI/ovUXeyC0UP/z7RvusYL092BbIwl0x0Bfg==",
+      "dependencies": {
+        "@ceramicnetwork/http-client": "^2.31.0",
         "@composedb/constants": "^0.5.0",
-        "@composedb/runtime": "^0.5.0",
+        "@composedb/runtime": "^0.5.1",
         "get-port": "^7.0.0",
         "graphql": "^16.8.0",
         "graphql-yoga": "^4.0.4"
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@composedb/server/node_modules/@ceramicnetwork/common": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-2.35.0.tgz",
+      "integrity": "sha512-1TsdVYAjTIVTBz+6dlrEJACFGqMzYZeOvwLNbpk9E5vMh6fnrgRm8q9JPeGhDyGwdGlY7l4e1yqzWAoZGnJARQ==",
+      "dependencies": {
+        "@ceramicnetwork/codecs": "^1.10.0",
+        "@ceramicnetwork/streamid": "^2.17.0",
+        "@didtools/cacao": "^2.1.0",
+        "@didtools/pkh-ethereum": "^0.1.0",
+        "@didtools/pkh-solana": "^0.1.0",
+        "@didtools/pkh-stacks": "^0.1.0",
+        "@didtools/pkh-tezos": "^0.2.1",
+        "@stablelib/random": "^1.0.1",
+        "caip": "~1.1.0",
+        "cross-fetch": "^3.1.4",
+        "flat": "^5.0.2",
+        "it-first": "^1.0.7",
+        "jet-logger": "1.2.2",
+        "lodash.clonedeep": "^4.5.0",
+        "logfmt": "^1.3.2",
+        "multiformats": "^11.0.1",
+        "rxjs": "^7.5.2",
+        "uint8arrays": "^4.0.3"
+      }
+    },
+    "node_modules/@composedb/server/node_modules/@ceramicnetwork/http-client": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/http-client/-/http-client-2.32.0.tgz",
+      "integrity": "sha512-2OUp33qXg2D243N+NwuwvPJfw/F2PFj2y73XT753yjwXIdyaHAJXwsoLJ8OyK1ixFYl1Q5Yb3kshO1sXurQi4g==",
+      "dependencies": {
+        "@ceramicnetwork/common": "^2.35.0",
+        "@ceramicnetwork/stream-caip10-link": "^2.30.0",
+        "@ceramicnetwork/stream-model": "^1.17.0",
+        "@ceramicnetwork/stream-model-instance": "^1.17.0",
+        "@ceramicnetwork/stream-tile": "^2.31.0",
+        "@ceramicnetwork/streamid": "^2.17.0",
+        "@scarf/scarf": "^1.1.1",
+        "query-string": "^7.1.0",
+        "rxjs": "^7.5.2"
+      }
+    },
+    "node_modules/@composedb/server/node_modules/@didtools/cacao": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@didtools/cacao/-/cacao-2.1.0.tgz",
+      "integrity": "sha512-35gopj+mOmAlA3nHoHiYMvNMXJtbJDJnVpIlCf/Wf/+/x+uG9aIQefXfF35D6JuaTCZ0apabjpT2umL5h3EXcw==",
+      "dependencies": {
+        "@didtools/codecs": "^1.0.1",
+        "@didtools/siwx": "1.0.0",
+        "@ipld/dag-cbor": "^9.0.1",
+        "caip": "^1.1.0",
+        "multiformats": "^11.0.2",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@composedb/server/node_modules/@ipld/dag-cbor": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.5.tgz",
+      "integrity": "sha512-TyqgtxEojc98rvxg4NGM+73JzQeM4+tK2VQes/in2mdyhO+1wbGuBijh1tvi9BErQ/dEblxs9v4vEQSX8mFCIw==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@composedb/server/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@composedb/server/node_modules/cborg": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.3.tgz",
+      "integrity": "sha512-poLvpK30KT5KI8gzDx3J/IuVCbsLqMT2fEbOrOuX0H7Hyj8yg5LezeWhRh9aLa5Z6MfPC5sriW3HVJF328M8LQ==",
+      "bin": {
+        "cborg": "lib/bin.js"
       }
     },
     "node_modules/@composedb/server/node_modules/get-port": {
@@ -6032,9 +6554,9 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.5.tgz",
-      "integrity": "sha512-ZTioQqg9z9eCG3j+KDy54k1gp6wRIsLqkx5yi163KVvXVkfjsrdErCyZjrEug21QnKE9piP4tyxMpMMOT1RuRw==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.6.tgz",
+      "integrity": "sha512-hZMjl/BbX10iagovakgf3IiqArx8TPsotq5pwBld37uIX1JiZoSbgbCIFol7u55bh32o6cfDEiiJgfAD5fbeyQ==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "dset": "^3.1.2",
@@ -12451,11 +12973,11 @@
       }
     },
     "node_modules/@whatwg-node/fetch": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
-      "integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
+      "version": "0.9.13",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.13.tgz",
+      "integrity": "sha512-PPtMwhjtS96XROnSpowCQM85gCUG2m7AXZFw0PZlGbhzx2GK7f2iOXilfgIJ0uSlCuuGbOIzfouISkA7C4FJOw==",
       "dependencies": {
-        "@whatwg-node/node-fetch": "^0.4.8",
+        "@whatwg-node/node-fetch": "^0.4.17",
         "urlpattern-polyfill": "^9.0.0"
       },
       "engines": {
@@ -12463,9 +12985,9 @@
       }
     },
     "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.14.tgz",
-      "integrity": "sha512-ii/eZz2PcjLGj9D6WfsmfzlTzZV1Kz6MxYpq2Vc5P21J8vkKfENWC9B2ISsFCKovxElLukIwPg8HTrHFsLNflg==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.19.tgz",
+      "integrity": "sha512-AW7/m2AuweAoSXmESrYQr/KBafueScNbn2iNO0u6xFr2JZdPmYsSm5yvAXYk6yDLv+eDmSSKrf7JnFZ0CsJIdA==",
       "dependencies": {
         "@whatwg-node/events": "^0.1.0",
         "busboy": "^1.6.0",
@@ -12478,11 +13000,11 @@
       }
     },
     "node_modules/@whatwg-node/server": {
-      "version": "0.9.13",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.9.13.tgz",
-      "integrity": "sha512-S4wL2RiAelX2gTE+jLRwd2Ep9v3qLai4LhRbw5TCLuquHh7CIqdpNhFDTHdEqE/OIgfy1OKOkRDYIhtCZqgLTQ==",
+      "version": "0.9.14",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.9.14.tgz",
+      "integrity": "sha512-I8TT0NoCP+xThLBuGlU6dgq5wpExkphNMo2geZwQW0vAmEPtc3MNMZMIYqg5GyNmpv5Nf7fnxb8tVOIHbDvuDA==",
       "dependencies": {
-        "@whatwg-node/fetch": "^0.9.7",
+        "@whatwg-node/fetch": "^0.9.10",
         "tslib": "^2.3.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "firstTime": "npx aws-sdk-js-codemod -t v2-to-v3 .",
+    "composites": "node ./scripts/composites.mjs",
     "generate": "node scripts/commands.mjs",
     "dev": "node scripts/run.mjs",
     "nextDev": "next dev",
@@ -20,8 +21,6 @@
     "@ceramicnetwork/http-client": "2.30.0",
     "@composedb/cli": "0.5.0",
     "@composedb/client": "0.5.0",
-    "@composedb/devtools": "0.5.0",
-    "@composedb/devtools-node": "0.5.0",
     "@didtools/cacao": "2.0.0",
     "@didtools/pkh-ethereum": "0.1.0",
     "@ethereum-attestation-service/eas-sdk": "^0.29.0",
@@ -51,6 +50,9 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
+    "@ceramicnetwork/stream-model": "^1.17.0",
+    "@composedb/devtools": "^0.5.0",
+    "@composedb/devtools-node": "^0.5.1",
     "@composedb/types": "^0.3.0",
     "@datamodels/identity-profile-basic": "^0.2.0",
     "@glazed/types": "^0.2.0",

--- a/scripts/composites.mjs
+++ b/scripts/composites.mjs
@@ -1,99 +1,111 @@
-import { readFileSync } from "fs";
-import { CeramicClient } from "@ceramicnetwork/http-client";
+import { readFileSync } from 'fs'
+import { CeramicClient } from '@ceramicnetwork/http-client'
 import {
   createComposite,
   readEncodedComposite,
   writeEncodedComposite,
   writeEncodedCompositeRuntime,
-} from "@composedb/devtools-node";
-import { Composite } from "@composedb/devtools";
-import { DID } from "dids";
-import { Ed25519Provider } from "key-did-provider-ed25519";
-import { getResolver } from "key-did-resolver";
-import { fromString } from "uint8arrays/from-string";
+} from '@composedb/devtools-node'
+import { DID } from 'dids'
+import { Ed25519Provider } from 'key-did-provider-ed25519'
+import { getResolver } from 'key-did-resolver'
+import { fromString } from 'uint8arrays/from-string'
+import ora from 'ora'
 
-const ceramic = new CeramicClient('http://localhost:7007');
+import { addAttestations } from './models-attestations.mjs'
+
+const ceramic = new CeramicClient('http://localhost:7007')
 
 /**
  * @param {Ora} spinner - to provide progress status.
  * @return {Promise<void>} - return void when composite finishes deploying.
  */
 export const writeComposite = async (spinner) => {
-  await authenticate();
-  spinner.info("writing composite to Ceramic");
+  await authenticate()
+  spinner.info('writing composite to Ceramic')
 
-  const researchComposite = await createComposite(
+  // @ts-ignore Ceramic client type
+  const researchComposite = await createComposite(ceramic, './composites/00-researchObject.graphql')
+
+  const composite = await addAttestations({
     ceramic,
-    "./composites/00-researchObject.graphql"
-  );
+    models: ['ResearchObjectAttestation'],
+    source: researchComposite,
+  })
 
-  const attestationSchema = readFileSync("./composites/00-attestation.graphql", {
-    encoding: "utf-8",
-  }).replace("$RESEARCH_ID", researchComposite.modelIDs[0]);
+  // const attestationSchema = readFileSync('./composites/00-attestation.graphql', {
+  //   encoding: 'utf-8',
+  // }).replace('$RESEARCH_ID', researchComposite.modelIDs[0])
 
-  const attestationComposite = await Composite.create({
-    ceramic,
-    schema: attestationSchema,
-  });
+  // const attestationComposite = await Composite.create({
+  //   ceramic,
+  //   schema: attestationSchema,
+  // })
 
-  const confirmSchema = readFileSync("./composites/01-confirm.graphql", {
-    encoding: "utf-8",
-  }).replace("$ATTESTATION_ID", attestationComposite.modelIDs[1]);
+  // // const attestationModelID = attestationComposite.modelIDs[1]
+  // // const model = await Model.load(ceramic, attestationModelID)
+  // // console.log('attestation model', JSON.stringify(model.content))
 
-  const confirmComposite = await Composite.create({
-    ceramic,
-    schema: confirmSchema,
-  });
+  // const confirmSchema = readFileSync('./composites/01-confirm.graphql', {
+  //   encoding: 'utf-8',
+  // }).replace('$ATTESTATION_ID', attestationComposite.modelIDs[1])
 
-  const confirmConnectSchema = readFileSync(
-    "./composites/02-confirmConnect.graphql",
-    {
-      encoding: "utf-8",
-    }
-  )
-    .replace("$CONFIRM_ID", confirmComposite.modelIDs[1])
-    .replace("$ATTESTATION_ID", attestationComposite.modelIDs[1]);
+  // const confirmComposite = await Composite.create({
+  //   ceramic,
+  //   schema: confirmSchema,
+  // })
+  // // const modelID = confirmComposite.modelIDs[1]
+  // // const model = await Model.load(ceramic, modelID)
+  // // console.log('attestation confirm model', JSON.stringify(model.content))
 
-  const confirmConnectComposite = await Composite.create({
-    ceramic,
-    schema: confirmConnectSchema,
-  });
+  // const confirmConnectSchema = readFileSync('./composites/02-confirmConnect.graphql', {
+  //   encoding: 'utf-8',
+  // })
+  //   .replace('$CONFIRM_ID', confirmComposite.modelIDs[1])
+  //   .replace('$ATTESTATION_ID', attestationComposite.modelIDs[1])
 
-  const composite = Composite.from([
-    researchComposite,
-    attestationComposite,
-    confirmComposite,
-    confirmConnectComposite,
-  ]);
+  // const confirmConnectComposite = await Composite.create({
+  //   ceramic,
+  //   schema: confirmConnectSchema,
+  // })
 
-  await writeEncodedComposite(composite, "./src/__generated__/definition.json");
-  spinner.info("creating composite for runtime usage");
+  // const composite = Composite.from([
+  //   researchComposite,
+  //   attestationComposite,
+  //   confirmComposite,
+  //   confirmConnectComposite,
+  // ])
+
+  // @ts-ignore Ceramic client type
+  await writeEncodedComposite(composite, './src/__generated__/definition.json')
+  spinner.info('creating composite for runtime usage')
   await writeEncodedCompositeRuntime(
+    // @ts-ignore Ceramic client type
     ceramic,
-    "./src/__generated__/definition.json",
-    "./src/__generated__/definition.js"
-  );
-  spinner.info("deploying composite");
-  const deployComposite = await readEncodedComposite(
-    ceramic,
-    "./src/__generated__/definition.json"
-  );
+    './src/__generated__/definition.json',
+    './src/__generated__/definition.js'
+  )
+  spinner.info('deploying composite')
+  // @ts-ignore Ceramic client type
+  const deployComposite = await readEncodedComposite(ceramic, './src/__generated__/definition.json')
 
-  await deployComposite.startIndexingOn(ceramic);
-  spinner.succeed("composite deployed & ready for use");
-};
+  await deployComposite.startIndexingOn(ceramic)
+  spinner.succeed('composite deployed & ready for use')
+}
 
 /**
  * Authenticating DID for publishing composite
  * @return {Promise<void>} - return void when DID is authenticated.
  */
 const authenticate = async () => {
-  const seed = readFileSync("./admin_seed.txt");
-  const key = fromString(seed, "base16");
+  const seed = readFileSync('./admin_seed.txt')
+  const key = fromString(seed, 'base16')
   const did = new DID({
     resolver: getResolver(),
     provider: new Ed25519Provider(key),
-  });
-  await did.authenticate();
-  ceramic.did = did;
-};
+  })
+  await did.authenticate()
+  ceramic.did = did
+}
+
+await writeComposite(ora())

--- a/scripts/models-attestations.mjs
+++ b/scripts/models-attestations.mjs
@@ -1,0 +1,243 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { CeramicClient } from '@ceramicnetwork/http-client'
+import { Model } from '@ceramicnetwork/stream-model'
+import { Composite } from '@composedb/devtools'
+import { DID } from 'dids'
+import { Ed25519Provider } from 'key-did-provider-ed25519'
+import { getResolver } from 'key-did-resolver'
+import { fromString } from 'uint8arrays'
+
+const CERAMIC_URL = process.env.CERAMIC_URL || 'http://localhost:7007'
+const SEED_PATH = fileURLToPath(new URL('../admin_seed.txt', import.meta.url))
+
+const COMMON_SCHEMA_DEFINITIONS = {
+  Types: {
+    type: 'object',
+    title: 'Types',
+    required: ['name', 'type'],
+    properties: {
+      name: { type: 'string', maxLength: 20 },
+      type: { type: 'string', maxLength: 20 },
+    },
+    additionalProperties: false,
+  },
+  CeramicStreamID: { type: 'string', title: 'CeramicStreamID', maxLength: 100 },
+  GraphQLDateTime: {
+    type: 'string',
+    title: 'GraphQLDateTime',
+    format: 'date-time',
+    maxLength: 100,
+  },
+}
+
+const ATTESTATION_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  type: 'object',
+  properties: {
+    r: { type: 'string', maxLength: 66, minLength: 66 },
+    s: { type: 'string', maxLength: 66, minLength: 66 },
+    v: { type: 'integer' },
+    uid: { type: 'string', maxLength: 66, minLength: 66 },
+    time: { type: 'integer' },
+    types: { type: 'array', items: { $ref: '#/$defs/Types' }, maxItems: 100 },
+    dataId: { $ref: '#/$defs/CeramicStreamID' },
+    refUID: { type: 'string', maxLength: 66, minLength: 66 },
+    schema: { type: 'string', maxLength: 66, minLength: 66 },
+    chainId: { type: 'integer' },
+    version: { type: 'integer' },
+    attester: { type: 'string', maxLength: 42, minLength: 42 },
+    recipient: { type: 'string', maxLength: 42, minLength: 42 },
+    easVersion: { type: 'string', maxLength: 5 },
+    expirationTime: { $ref: '#/$defs/GraphQLDateTime' },
+    revocationTime: { $ref: '#/$defs/GraphQLDateTime' },
+    verifyingContract: { type: 'string', maxLength: 42, minLength: 42 },
+  },
+  additionalProperties: false,
+  required: [
+    'uid',
+    'schema',
+    'attester',
+    'verifyingContract',
+    'easVersion',
+    'version',
+    'chainId',
+    'r',
+    's',
+    'v',
+    'time',
+    'dataId',
+  ],
+
+  $defs: COMMON_SCHEMA_DEFINITIONS,
+}
+
+const CONFIRMATION_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  type: 'object',
+  properties: {
+    r: { type: 'string', maxLength: 66, minLength: 66 },
+    s: { type: 'string', maxLength: 66, minLength: 66 },
+    v: { type: 'integer' },
+    uid: { type: 'string', maxLength: 66, minLength: 66 },
+    data: { type: 'string', maxLength: 1000000 },
+    time: { type: 'integer' },
+    types: { type: 'array', items: { $ref: '#/$defs/Types' }, maxItems: 100 },
+    refUID: { type: 'string', maxLength: 66, minLength: 66 },
+    schema: { type: 'string', maxLength: 66, minLength: 66 },
+    chainId: { type: 'integer' },
+    version: { type: 'integer' },
+    attester: { type: 'string', maxLength: 42, minLength: 42 },
+    recipient: { type: 'string', maxLength: 42, minLength: 42 },
+    easVersion: { type: 'string', maxLength: 5 },
+    attestationId: { $ref: '#/$defs/CeramicStreamID' },
+    expirationTime: { $ref: '#/$defs/GraphQLDateTime' },
+    revocationTime: { $ref: '#/$defs/GraphQLDateTime' },
+    verifyingContract: { type: 'string', maxLength: 42, minLength: 42 },
+  },
+  additionalProperties: false,
+  required: [
+    'uid',
+    'schema',
+    'attester',
+    'verifyingContract',
+    'easVersion',
+    'version',
+    'chainId',
+    'r',
+    's',
+    'v',
+    'time',
+    'data',
+    'attestationId',
+  ],
+  $defs: COMMON_SCHEMA_DEFINITIONS,
+}
+
+async function getCeramicClient(provided) {
+  const seed = await readFile(SEED_PATH, 'utf8')
+  const key = fromString(seed, 'base16')
+  const did = new DID({
+    // @ts-ignore resolver type mismatch
+    resolver: getResolver(),
+    provider: new Ed25519Provider(key),
+  })
+  await did.authenticate()
+
+  const ceramic =
+    provided instanceof CeramicClient ? provided : new CeramicClient(provided ?? CERAMIC_URL)
+  ceramic.did = did
+  return ceramic
+}
+
+// Create an attestation model for the given model ID and name
+async function createAttestationModels(ceramic, forModelID, forModelName) {
+  const attestationModel = await Model.create(ceramic, {
+    version: '1.0',
+    name: `AttestationFor${forModelName}`,
+    description: `Ethereum attestation for documents of model ${forModelName}`,
+    accountRelation: { type: 'list' },
+    schema: ATTESTATION_SCHEMA,
+    relations: {
+      dataId: { type: 'document', model: forModelID },
+    },
+    views: {
+      data: { type: 'relationDocument', model: forModelID, property: 'dataId' },
+      publisher: { type: 'documentAccount' },
+    },
+  })
+  const attestationID = attestationModel.id.toString()
+
+  const confirmationModel = await Model.create(ceramic, {
+    version: '1.0',
+    name: `AttestationConfirmationFor${forModelName}`,
+    description: `Ethereum attestation confirmation for documents of model ${forModelName}`,
+    accountRelation: { type: 'list' },
+    schema: CONFIRMATION_SCHEMA,
+    relations: {
+      attestationId: { type: 'document', model: attestationID },
+    },
+    views: {
+      attestation: { type: 'relationDocument', model: attestationID, property: 'attestationId' },
+      publisher: { type: 'documentAccount' },
+    },
+  })
+
+  await ceramic.admin.startIndexingModelData([
+    {
+      streamID: attestationModel.id,
+      indices: [
+        { fields: [{ path: ['attester'] }] },
+        { fields: [{ path: ['verifyingContract'] }] },
+      ],
+    },
+    {
+      streamID: confirmationModel.id,
+      indices: [{ fields: [{ path: ['attester'] }] }, { fields: [{ path: ['recipient'] }] }],
+    },
+  ])
+
+  return { attestationID, confirmationID: confirmationModel.id.toString() }
+}
+
+export async function addAttestations({ ceramic, models, source }) {
+  const { definition } = source.toParams()
+  // Create mapping of model IDs by their name
+  const modelIDsByName = Object.entries(definition.models).reduce(
+    (acc, [modelID, modelDefinition]) => {
+      acc[modelDefinition.name] = modelID
+      return acc
+    },
+    {}
+  )
+
+  // Create the attestation model for each model name provided
+  const attestationIDsByName = {}
+  const attestationModelsIDs = await Promise.all(
+    models.map(async (modelName) => {
+      const modelID = modelIDsByName[modelName]
+      if (modelID == null) {
+        throw new Error(`Model ID not found for model: ${modelName}`)
+      }
+      const models = await createAttestationModels(ceramic, modelID, modelName)
+      attestationIDsByName[modelName] = models
+      return Object.values(models)
+    })
+  )
+
+  // Create new composite containing the created attestation models
+  const attestationsComposite = await Composite.fromModels({
+    ceramic,
+    models: attestationModelsIDs.flat(),
+  })
+
+  // Create views to the attestations for the provided models
+  const modelViews = Object.entries(attestationIDsByName).reduce(
+    (acc, [forModelName, relatedModels]) => {
+      acc[forModelName] = {
+        // attestations: {
+        //   type: 'relationFrom',
+        //   model: relatedModels.attestationID,
+        //   property: 'dataId',
+        // },
+        // attestationsCount: {
+        //   type: 'relationCountFrom',
+        //   model: relatedModels.attestationID,
+        //   property: 'dataId',
+        // },
+        confirm: {
+          type: 'relationFrom',
+          model: relatedModels.confirmationID,
+          property: 'attestationId',
+        },
+      }
+      return acc
+    },
+    {}
+  )
+
+  // Create new composite combining the source one with attestations models and additional views
+  return Composite.from([source, attestationsComposite], {
+    views: { models: modelViews },
+  })
+}


### PR DESCRIPTION
These changes mainly replace pieces of the logic in the `composites.mjs` by a generic function to create attestation models for a given input composite and model(s).
I haven't tried using the generated definition at runtime, any pointers at steps to take to make sure the generated composite works please?